### PR TITLE
Fix id-add failing to Claim/Link

### DIFF
--- a/immp/hook/identitylocal.py
+++ b/immp/hook/identitylocal.py
@@ -250,7 +250,7 @@ class LocalIdentityHook(immp.Hook, AccessPredicate, IdentityProvider):
         """
         if not msg.user or msg.user.plug not in self._plugs:
             return
-        if self.find(msg.user):
+        if await self.find(msg.user):
             text = "{} Already identified".format(CROSS)
         else:
             pwd = IdentityGroup.hash(pwd)


### PR DESCRIPTION
Since `self.find(user)` is async, it needs to be awaited for the correct result to be retrieved.
This was causing `[prefix] id-add <username> <password>` to fail for all new claims/links.

This had been working in Python 3.8, but something looks to have changed in Python 3.9 to break it.